### PR TITLE
Add debug logging helper

### DIFF
--- a/src/detraf/log.py
+++ b/src/detraf/log.py
@@ -1,6 +1,8 @@
 
 from __future__ import annotations
 from datetime import datetime
+import os
+from pathlib import Path
 
 def _ts() -> str:
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -23,3 +25,17 @@ def warn(msg: str) -> None:
 
 def err(msg: str) -> None:
     print(f"{_ts()} ERRO {msg}")
+
+
+def debug(msg: str) -> None:
+    """Registra mensagem de depuração quando DETRAF_DEBUG estiver ativada."""
+
+    if "DETRAF_DEBUG" not in os.environ:
+        return
+
+    log_dir = Path("var/logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "match_debug.log"
+
+    with log_file.open("a", encoding="utf-8") as fp:
+        fp.write(f"{_ts()} DEBUG {msg}\n")


### PR DESCRIPTION
## Summary
- add a debug logging helper that writes to `var/logs/match_debug.log` when `DETRAF_DEBUG` is set
- ensure the log directory is created automatically before writing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8904c32ec8333a6f37ecd8f6ca0f4