### PR TITLE
Add debug diagnostics for CDR matching

### DIFF
--- a/src/detraf/log.py
+++ b/src/detraf/log.py
@@ -15,6 +15,9 @@ header = section
 def info(msg: str) -> None:
     print(f"{_ts()} {msg}")
 
+def debug(msg: str) -> None:
+    print(f"{_ts()} DEBUG {msg}")
+
 def ok(msg: str) -> None:
     print(f"{_ts()} OK {msg}")
 


### PR DESCRIPTION
## Summary
- add a DEBUG log helper to the local logging facade
- log candidate-count anomalies and decision inputs while processing DETRAF/CDR matches

## Testing
- python -m compileall src/detraf/match_cdr.py

------
https://chatgpt.com/codex/tasks/task_e_68c8904b092c8333aacbb8d96f52422a